### PR TITLE
docs: describe emacsclient config

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Override the default arguments to use a single instance of the Vim editor and op
 
 The Vim should be compiled with `+clientserver` flag. Please run the `vim --version` and check the output.
 
+#### Emacs
+
+Use emacsclient to use an existing Emacs instance instead opening emacs in a terminal.
+
+    "alt-editor.binary": "emacsclient",
+    "alt-editor.args": "--alternate-editor=emacs --no-wait +{line}:{column} {filename}"
+
 ## For more information
 
 -   Powered by [open-in-editor](https://github.com/lahmatiy/open-in-editor)


### PR DESCRIPTION
For emacs it is better to use `emacsclient` to open a file in an existing (or new) graphical Emacs window instead of starting the terminal version of Emacs in a new terminal window. The PR updates the README to describe how to do that.